### PR TITLE
Add delay based on systick

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Tell rustc to pass linker scripts to LLD
+    println!("cargo:rustc-link-arg=-Tmemory.x");
+    println!("cargo:rustc-link-arg=-Tlink.x");
+
+    // Rerun this script only when necesary
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,0 +1,28 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+use riscv_rt::entry;
+use riscv;
+use ch32v00x_hal::{gpio::GpioExt, prelude::*, timer::delay::SysDelay};
+use embedded_hal::digital::v2::ToggleableOutputPin;
+
+#[entry]
+fn main() -> ! {
+    // To ensure safe access to peripherals, all types are !Copy singletons. The
+    // PAC makes us pass these marker types around to access the registers
+    let p = ch32v0::ch32v003::Peripherals::take().unwrap();
+
+    let mut rcc = p.RCC.constrain();
+    let gpioc = p.GPIOC.split(&mut rcc);
+
+    let clocks = rcc.config.freeze();
+    let mut pc1 = gpioc.pc1.into_push_pull_output();
+
+    let mut delay = SysDelay::new(p.SYSTICK, 24);
+    loop {
+        // Toggle pin 1
+        pc1.toggle();
+        delay.delay(500_000);
+    }
+}

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -3,9 +3,9 @@
 
 use panic_halt as _;
 use riscv_rt::entry;
-use riscv;
 use ch32v00x_hal::{gpio::GpioExt, prelude::*, timer::delay::SysDelay};
 use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal::blocking::delay::DelayMs;
 
 #[entry]
 fn main() -> ! {
@@ -17,12 +17,13 @@ fn main() -> ! {
     let gpioc = p.GPIOC.split(&mut rcc);
 
     let clocks = rcc.config.freeze();
+    let mut delay = SysDelay::new(p.SYSTICK, &clocks);
+
     let mut pc1 = gpioc.pc1.into_push_pull_output();
 
-    let mut delay = SysDelay::new(p.SYSTICK, 24);
     loop {
         // Toggle pin 1
         pc1.toggle();
-        delay.delay(500_000);
+        delay.delay_ms(500_u16);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ pub mod delay;
 // #[cfg(feature = "device-selected")]
 // pub mod signature;
 
-// #[cfg(feature = "device-selected")]
-// pub mod timer;
+#[cfg(feature = "device-selected")]
+pub mod timer;
 
 pub mod state {
     /// Indicates that a peripheral is enabled

--- a/src/timer/delay.rs
+++ b/src/timer/delay.rs
@@ -1,41 +1,86 @@
 //! Delays
-use crate::{pac::SYSTICK};
-use core::ops::{Deref, DerefMut};
-use fugit::{MicrosDurationU32, TimerDurationU32};
+use crate::pac::SYSTICK;
+use crate::rcc::Clocks;
 
-const SYSTICK_RANGE: u32 = 0x8000_0000;
-
-/// Timer as a delay provider (SYSTICKick by default)
+/// A delay using the systick timer
+///
+/// Timing mostly doesn't vary from interrupts
 pub struct SysDelay {
-    pub systick: SYSTICK,
+    systick: SYSTICK,
     scale: u32,
+    // The SysTick counter has a width of 32 bits and will be configured to run freely.
+    // We'll only wait half the theoretically possible time to have some leeway in case of interrupts.
+    max_us: u32
 }
 
 impl SysDelay {
-    pub fn new(systick: SYSTICK, scale: u32) -> Self {
-        systick.ctlr.write(|w| w.stre().set_bit().stclk().set_bit().ste().set_bit());
-        unsafe {systick.cmpr.write(|w| w.cmp().bits(SYSTICK_RANGE - 1))};
+    pub fn new(systick: SYSTICK, clocks: &Clocks) -> Self {
+        systick.ctlr.write(|w| w.stclk().set_bit().ste().set_bit());
+        let scale = clocks.hclk().to_MHz() as u32;
         SysDelay {
-            systick, scale
+            systick,
+            scale,
+            max_us: (8000_0000u32 / scale) - 1,
         }
     }
+}
 
-    pub fn delay(&mut self, us: u32) {
-        // The SysTick Reload Value register supports values between 1 and 0x7FFFFFFF.
-        // Here less than maximum is used so we have some play if there's a long running interrupt.
-        const MAX_RVR: u32 = SYSTICK_RANGE / 2 - 1;
-
-        let mut total_rvr = us * self.scale;
-
-
-        while total_rvr != 0 {
-            let current_rvr = total_rvr.min(MAX_RVR);
+impl embedded_hal_alpha::delay::DelayUs for SysDelay {
+    fn delay_us(&mut self, mut us: u32) {
+        // Scale the us inside the loop, to avoid overflow scenarios
+        while us != 0 {
+            let current_us = us.min(self.max_us);
+            let current_rvr = current_us * self.scale;
 
             let start_rvr = self.systick.cnt.read().cnt().bits();
             // Update the tracking variable while we are waiting...
-            total_rvr -= current_rvr;
-            // Use the wrapping substraction and the modulo to deal with the systick wrapping around
-            while (self.systick.cnt.read().cnt().bits().wrapping_sub(start_rvr)) % SYSTICK_RANGE < current_rvr {}
+            us -= current_us;
+            // Use the wrapping substraction to deal with the systick wrapping around
+            while (self.systick.cnt.read().cnt().bits().wrapping_sub(start_rvr)) < current_rvr {}
         }
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayUs<u32> for SysDelay {
+    fn delay_us(&mut self, us: u32) {
+        embedded_hal_alpha::delay::DelayUs::delay_us(self, us as _);
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayUs<u16> for SysDelay {
+    fn delay_us(&mut self, us: u16) {
+        embedded_hal_alpha::delay::DelayUs::delay_us(self, us as _);
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayUs<u8> for SysDelay {
+    fn delay_us(&mut self, us: u8) {
+        embedded_hal_alpha::delay::DelayUs::delay_us(self, us as _);
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayMs<u32> for SysDelay {
+    // Multiplying ms so we can call delay_us directly might overflow, so implement an outer loop
+    fn delay_ms(&mut self, mut ms: u32) {
+        const MAX_MS: u32 = 0x0010_0000;
+        while ms != 0 {
+            let current_ms = if ms <= MAX_MS { ms } else { MAX_MS };
+            embedded_hal::blocking::delay::DelayUs::delay_us(self, current_ms as u32 * 1_000);
+            ms -= current_ms;
+        }
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayMs<u16> for SysDelay {
+    fn delay_ms(&mut self, ms: u16) {
+        // Call delay_us directly, so we don't have to use the additional
+        // delay loop the u32 variant uses
+        embedded_hal::blocking::delay::DelayUs::delay_us(self, ms as u32 * 1_000);
+    }
+}
+
+impl embedded_hal::blocking::delay::DelayMs<u8> for SysDelay {
+    fn delay_ms(&mut self, ms: u8) {
+        self.delay_ms(ms as u16);
     }
 }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -1,0 +1,1 @@
+pub mod delay;


### PR DESCRIPTION
I think this would also make sense as a default delay implementation.

Since the delay function only reads the `CNT` register, we could steal access to the peripheral on each delay call and make `SysDelay` `Copy`, which is always nice.

Depends on https://github.com/ch32-rs/ch32-rs/pull/15