### PR TITLE
add nightly cargo to prerequisites in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The ch32-rs team maintains an updated branch for Rust with riscv32ec support.
 ### Prerequisites
 
 - A working Rust installation (rustup)
+- A nightly Cargo in your channels
 - Build essentials (gcc, make, ninja, etc.) and git
 
 ### Build a Rust compiler with riscv32ec support
@@ -73,7 +74,8 @@ To see if `riscv32ec-unknown-non-elf` is in the list.
 
 ### Project toolchain override
 
-In this project directory, run `rustup override set custom-rv32ec` to set default toolchain to the one we just built.
+- In this project directory, run `rustup override set custom-rv32ec` to set default toolchain to the one we just built.
+- run `cargo --version` and ensure the result is nightly Cargo(otherwise, the easiest way to get one is, run `rustup toolchain install nightly`)
 
 ## References
 


### PR DESCRIPTION
Building a project with a custom toolchain requires nightly cargo.
And the only way to get nightly cargo is `rustup toolchain install nightly`.(though there may be alternatives.)

Without nightly cargo, you can't build `core` library.
If you don't have it, `cargo build` on your project will throw a bunch of errors, something like
```
error[E0425]: cannot find function, tuple struct or tuple variant `Some` in this scope
   --> /Users/DicklessGreat/.cargo/registry/src/index.crates.io-6f17d22bba15001f/version_check-0.9.4/src/lib.rs:292:31
    |
292 |         Some(false) => return Some(false),
    |                               ^^^^ not found in this scope
```
You will find other basic types and literals missing.
You can reproduce these errors by 
1, `rustup toolchain uninstall nightly`(at anywhere)
2, `cargo +custom-rv32ec build`(on your project)

The reason why you can't build `core` lib is that stable cargo ignores `build-std` in `.cargo/config.toml`.
Because `build-std` is `unstable` cargo feature, we have to use nightly cargo.
https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
That's why we need to `rustup toolchain install nightly` and it is a prerequisites.
(And as you already notice, it installs unnecessary toolchain, something like `nightly-x86_64-apple-darwin` on my machine.Is there any way to install nightly cargo only? I'm not 100% sure the best way to get nightly Cargo.)

You can check which version your Cargo is called by`cargo --version`.
And here is the interesting experiment that makes me confirm what caused the core library build failure.
```
$ cargo --version
cargo 1.74.0 (ecb9851af 2023-10-18)
$ cargo +custom-rv32ec --version
cargo 1.77.0-nightly (84976cd69 2024-01-12)
$ rustup toolchain uninstall nightly
info: uninstalling toolchain 'nightly-x86_64-unknown-linux-gnu'
info: toolchain 'nightly-x86_64-unknown-linux-gnu' uninstalled
$ cargo +custom-rv32ec --version
cargo 1.74.0 (ecb9851af 2023-10-18)
```
As mentioned in the rustup book, rustup seeks cargo from the toolchain, and if there isn't, seeks your channels.
```
Because the rust-lang/rust tree does not include Cargo, when cargo is invoked for a custom toolchain and it is not available, rustup will attempt to use cargo from one of the release channels, preferring 'nightly', then 'beta' or 'stable'.
```
https://rust-lang.github.io/rustup/concepts/toolchains.html