### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a WIP implementation of the embedded-hal traits for the CH32V0 family of
 
 > **UPDATE**
 >
-> CH461 is also a RISCV32EC core.
+> CH641 is also a RISCV32EC core.
 
 ## Peripheral status
 


### PR DESCRIPTION
CH641 系列是基于青稞 RISC-V2A 内核设计的 PD 无线充电专用微控制器。