### PR TITLE
Add `rust-toolchain.toml` to use `nightly` channel by default

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
As it stands, using nightly is required, so why not add a `rust-toolchain.toml` :)

That we we don't have to specify `cargo +nightly ...`.